### PR TITLE
Added email utility class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka</artifactId>
 		</dependency>

--- a/src/main/java/rs/teslaris/core/controller/DummyController.java
+++ b/src/main/java/rs/teslaris/core/controller/DummyController.java
@@ -1,15 +1,26 @@
 package rs.teslaris.core.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import rs.teslaris.core.util.email.EmailUtil;
 
 @RestController
 @RequestMapping("/api/dummy")
+@RequiredArgsConstructor
 public class DummyController {
+
+    private final EmailUtil emailUtil;
 
     @GetMapping
     public String returnDummyData() {
         return "TEST";
+    }
+
+    @PostMapping
+    public void testEmail() {
+        emailUtil.sendSimpleEmail("email@email.com", "SUBJECT", "TEXT");
     }
 }

--- a/src/main/java/rs/teslaris/core/util/email/EmailUtil.java
+++ b/src/main/java/rs/teslaris/core/util/email/EmailUtil.java
@@ -1,0 +1,24 @@
+package rs.teslaris.core.util.email;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailUtil {
+
+    private final JavaMailSender mailSender;
+
+    @Async
+    public void sendSimpleEmail(String to, String subject, String text) {
+        var message = new SimpleMailMessage();
+        message.setFrom("nekinasemail@email.com");
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/rs/teslaris/core/util/email/EmailUtil.java
+++ b/src/main/java/rs/teslaris/core/util/email/EmailUtil.java
@@ -13,7 +13,7 @@ public class EmailUtil {
 
     private final JavaMailSender mailSender;
 
-    @Value("${email.address}")
+    @Value("${mail.sender.address}")
     private String emailAddress;
 
     @Async

--- a/src/main/java/rs/teslaris/core/util/email/EmailUtil.java
+++ b/src/main/java/rs/teslaris/core/util/email/EmailUtil.java
@@ -1,6 +1,7 @@
 package rs.teslaris.core.util.email;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.Async;
@@ -12,10 +13,13 @@ public class EmailUtil {
 
     private final JavaMailSender mailSender;
 
+    @Value("${email.address}")
+    private String emailAddress;
+
     @Async
     public void sendSimpleEmail(String to, String subject, String text) {
         var message = new SimpleMailMessage();
-        message.setFrom("nekinasemail@email.com");
+        message.setFrom(emailAddress);
         message.setTo(to);
         message.setSubject(subject);
         message.setText(text);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,7 +16,7 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.open-in-view=false
 
 # MAIL - !! DEVELOPMENT ONLY !!
-email.address=nekinasemail@email.com
+mail.sender.address=nekinasemail@email.com
 spring.mail.host=localhost
 spring.mail.port=1025
 spring.mail.username=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,11 @@ spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.open-in-view=false
+
+# MAIL - !! DEVELOPMENT ONLY !!
+spring.mail.host=localhost
+spring.mail.port=1025
+spring.mail.username=
+spring.mail.password=
+spring.mail.properties.mail.smtp.auth=false
+spring.mail.properties.mail.smtp.starttls.enable=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,7 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.open-in-view=false
 
 # MAIL - !! DEVELOPMENT ONLY !!
+email.address=nekinasemail@email.com
 spring.mail.host=localhost
 spring.mail.port=1025
 spring.mail.username=


### PR DESCRIPTION
Added utility class capable of sending simple emails (with from, to, subject and content fields) as well as dummy http endpoint to test the functionality for the time being. Currently the SMTP server is configured to be [fake-smtp-server](https://www.npmjs.com/package/fake-smtp-server), we should discuss which concrete server we will use in the future.