### PR TITLE
Added taking of role functionality.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
 			<version>0.9.1</version>
 		</dependency>
 		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>31.1-jre</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>

--- a/src/main/java/rs/teslaris/DbInitializer.java
+++ b/src/main/java/rs/teslaris/DbInitializer.java
@@ -32,17 +32,26 @@ public class DbInitializer implements ApplicationRunner {
     @Override
     @Transactional
     public void run(ApplicationArguments args) throws Exception {
-        var adminRead = new Privilege("ADMIN_READ");
-        var adminWrite = new Privilege("ADMIN_WRITE");
-        var adminDelete = new Privilege("ADMIN_DELETE");
-        privilegeRepository.saveAll(Arrays.asList(adminRead, adminWrite, adminDelete));
+        var allowAccountTakeover = new Privilege("ALLOW_ACCOUNT_TAKEOVER");
+        var takeRoleOfUser = new Privilege("TAKE_ROLE");
+        privilegeRepository.saveAll(
+            Arrays.asList(allowAccountTakeover, takeRoleOfUser));
 
         var adminAuthority = new Authority("ADMIN",
-            new HashSet<>(List.of(new Privilege[] {adminRead, adminWrite, adminDelete})));
+            new HashSet<>(
+                List.of(new Privilege[] {takeRoleOfUser})));
+        var authorAuthority =
+            new Authority("AUTHOR", new HashSet<>(List.of(new Privilege[] {allowAccountTakeover})));
         authorityRepository.save(adminAuthority);
+        authorityRepository.save(authorAuthority);
 
         var adminUser =
-            new User("admin@admin.com", passwordEncoder.encode("admin"), false, adminAuthority);
+            new User("admin@admin.com", passwordEncoder.encode("admin"), false, false,
+                adminAuthority);
+        var authorUser =
+            new User("author@author.com", passwordEncoder.encode("author"), false, false,
+                authorAuthority);
         userRepository.save(adminUser);
+        userRepository.save(authorUser);
     }
 }

--- a/src/main/java/rs/teslaris/TeslarisStarter.java
+++ b/src/main/java/rs/teslaris/TeslarisStarter.java
@@ -3,11 +3,13 @@ package rs.teslaris;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
 @SpringBootApplication
 @EnableAutoConfiguration
 @EnableWebSecurity
+@EnableScheduling
 public class TeslarisStarter {
 
     public static void main(String[] args) {

--- a/src/main/java/rs/teslaris/core/configuration/SecurityConfiguration.java
+++ b/src/main/java/rs/teslaris/core/configuration/SecurityConfiguration.java
@@ -57,6 +57,7 @@ public class SecurityConfiguration {
 
             // BASIC ENDPOINT CONFIGURATION
             .antMatchers(HttpMethod.POST, "/api/user/authenticate").permitAll()
+            .antMatchers(HttpMethod.POST, "/api/user/refresh-token").permitAll()
             .anyRequest().fullyAuthenticated();
 
         http.headers().xssProtection().and().contentSecurityPolicy("script-src 'self'");

--- a/src/main/java/rs/teslaris/core/controller/UserController.java
+++ b/src/main/java/rs/teslaris/core/controller/UserController.java
@@ -4,15 +4,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import rs.teslaris.core.dto.AuthenticationRequestDTO;
 import rs.teslaris.core.dto.AuthenticationResponseDTO;
+import rs.teslaris.core.dto.TakeRoleOfUserRequestDTO;
+import rs.teslaris.core.service.UserService;
 import rs.teslaris.core.util.jwt.JwtUtil;
 
 @RestController
@@ -24,22 +28,46 @@ public class UserController {
 
     private final JwtUtil tokenUtil;
 
+    private final UserService userService;
+
 
     @PostMapping("/authenticate")
     public ResponseEntity<AuthenticationResponseDTO> authenticateUser(
         @RequestBody AuthenticationRequestDTO authenticationRequest) {
-        var authentication = authenticationManager.authenticate(
-            new UsernamePasswordAuthenticationToken(authenticationRequest.getEmail(),
-                authenticationRequest.getPassword())
-        );
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+        var fingerprint = tokenUtil.generateJWTSecurityFingerprint();
+
+        var token =
+            userService.authenticateUser(authenticationManager, authenticationRequest, fingerprint);
+
+        var headers = getJwtSecurityCookieHeader(fingerprint);
+        return new ResponseEntity<>(new AuthenticationResponseDTO(token), headers, HttpStatus.OK);
+    }
+
+    @PostMapping("/take-role")
+    @PreAuthorize("hasAuthority('TAKE_ROLE')")
+    public ResponseEntity<AuthenticationResponseDTO> takeRoleOfUser(
+        @RequestBody TakeRoleOfUserRequestDTO takeRoleRequest) {
 
         var fingerprint = tokenUtil.generateJWTSecurityFingerprint();
-        var token = tokenUtil.generateToken(authentication, fingerprint);
 
+        var token = userService.takeRoleOfUser(takeRoleRequest, fingerprint);
+
+        var headers = getJwtSecurityCookieHeader(fingerprint);
+        return new ResponseEntity<>(new AuthenticationResponseDTO(token), headers, HttpStatus.OK);
+    }
+
+    @PatchMapping("/allow-role-taking")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasAuthority('ALLOW_ACCOUNT_TAKEOVER')")
+    public void allowTakingRoleOfAccount(@RequestHeader("Authorization") String bearerToken) {
+        userService.allowTakingRoleOfAccount(bearerToken);
+    }
+
+    private HttpHeaders getJwtSecurityCookieHeader(String fingerprint) {
         var headers = new HttpHeaders();
         headers.add("Set-Cookie",
             "jwt-security-fingerprint=" + fingerprint + "; SameSite=Strict; HttpOnly; Path=/api");
-        return new ResponseEntity<>(new AuthenticationResponseDTO(token), headers, HttpStatus.OK);
+
+        return headers;
     }
 }

--- a/src/main/java/rs/teslaris/core/controller/UserController.java
+++ b/src/main/java/rs/teslaris/core/controller/UserController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import rs.teslaris.core.dto.AuthenticationRequestDTO;
 import rs.teslaris.core.dto.AuthenticationResponseDTO;
+import rs.teslaris.core.dto.RefreshTokenRequestDTO;
 import rs.teslaris.core.dto.TakeRoleOfUserRequestDTO;
 import rs.teslaris.core.service.UserService;
 import rs.teslaris.core.util.jwt.JwtUtil;
@@ -36,11 +37,23 @@ public class UserController {
         @RequestBody AuthenticationRequestDTO authenticationRequest) {
         var fingerprint = tokenUtil.generateJWTSecurityFingerprint();
 
-        var token =
+        var authenticationResponse =
             userService.authenticateUser(authenticationManager, authenticationRequest, fingerprint);
 
         var headers = getJwtSecurityCookieHeader(fingerprint);
-        return new ResponseEntity<>(new AuthenticationResponseDTO(token), headers, HttpStatus.OK);
+        return new ResponseEntity<>(authenticationResponse, headers, HttpStatus.OK);
+    }
+
+    @PostMapping("/refresh-token")
+    public ResponseEntity<AuthenticationResponseDTO> refreshToken(
+        @RequestBody RefreshTokenRequestDTO refreshTokenRequest) {
+        var fingerprint = tokenUtil.generateJWTSecurityFingerprint();
+
+        var authenticationResponse =
+            userService.refreshToken(refreshTokenRequest.getRefreshTokenValue(), fingerprint);
+
+        var headers = getJwtSecurityCookieHeader(fingerprint);
+        return new ResponseEntity<>(authenticationResponse, headers, HttpStatus.OK);
     }
 
     @PostMapping("/take-role")
@@ -50,10 +63,10 @@ public class UserController {
 
         var fingerprint = tokenUtil.generateJWTSecurityFingerprint();
 
-        var token = userService.takeRoleOfUser(takeRoleRequest, fingerprint);
+        var authenticationResponse = userService.takeRoleOfUser(takeRoleRequest, fingerprint);
 
         var headers = getJwtSecurityCookieHeader(fingerprint);
-        return new ResponseEntity<>(new AuthenticationResponseDTO(token), headers, HttpStatus.OK);
+        return new ResponseEntity<>(authenticationResponse, headers, HttpStatus.OK);
     }
 
     @PatchMapping("/allow-role-taking")

--- a/src/main/java/rs/teslaris/core/dto/RefreshTokenRequestDTO.java
+++ b/src/main/java/rs/teslaris/core/dto/RefreshTokenRequestDTO.java
@@ -9,9 +9,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class AuthenticationResponseDTO {
+public class RefreshTokenRequestDTO {
 
-    private String token;
-
-    private String refreshToken;
+    private String refreshTokenValue;
 }

--- a/src/main/java/rs/teslaris/core/dto/TakeRoleOfUserRequestDTO.java
+++ b/src/main/java/rs/teslaris/core/dto/TakeRoleOfUserRequestDTO.java
@@ -1,0 +1,15 @@
+package rs.teslaris.core.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TakeRoleOfUserRequestDTO {
+
+    private String userEmail;
+}

--- a/src/main/java/rs/teslaris/core/exception/NonExistingRefreshTokenException.java
+++ b/src/main/java/rs/teslaris/core/exception/NonExistingRefreshTokenException.java
@@ -1,0 +1,8 @@
+package rs.teslaris.core.exception;
+
+public class NonExistingRefreshTokenException extends RuntimeException {
+
+    public NonExistingRefreshTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/rs/teslaris/core/exception/TakeOfRoleNotPermittedException.java
+++ b/src/main/java/rs/teslaris/core/exception/TakeOfRoleNotPermittedException.java
@@ -1,0 +1,8 @@
+package rs.teslaris.core.exception;
+
+public class TakeOfRoleNotPermittedException extends RuntimeException {
+
+    public TakeOfRoleNotPermittedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/rs/teslaris/core/model/BaseEntity.java
+++ b/src/main/java/rs/teslaris/core/model/BaseEntity.java
@@ -1,13 +1,18 @@
 package rs.teslaris.core.model;
 
+import java.util.Date;
+import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
 
 @Getter
 @Setter
@@ -19,4 +24,9 @@ public abstract class BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
+
+    @CreationTimestamp
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "created_at")
+    private Date createDate;
 }

--- a/src/main/java/rs/teslaris/core/model/RefreshToken.java
+++ b/src/main/java/rs/teslaris/core/model/RefreshToken.java
@@ -1,0 +1,29 @@
+package rs.teslaris.core.model;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "refresh_tokens")
+public class RefreshToken extends BaseEntity {
+
+    @Column(name = "refresh_token_value")
+    private String refreshTokenValue;
+
+    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.MERGE)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/rs/teslaris/core/model/User.java
+++ b/src/main/java/rs/teslaris/core/model/User.java
@@ -32,6 +32,9 @@ public class User extends BaseEntity implements UserDetails {
     @Column(name = "locked", nullable = false)
     private Boolean locked;
 
+    @Column(name = "can_take_role", nullable = false)
+    private Boolean canTakeRole;
+
     @ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.MERGE)
     @JoinColumn(name = "authority_id")
     private Authority authority;

--- a/src/main/java/rs/teslaris/core/repository/RefreshTokenRepository.java
+++ b/src/main/java/rs/teslaris/core/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package rs.teslaris.core.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import rs.teslaris.core.model.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Integer> {
+
+    @Query("select t from RefreshToken t where t.refreshTokenValue = :refreshTokenValue")
+    Optional<RefreshToken> getRefreshToken(String refreshTokenValue);
+}

--- a/src/main/java/rs/teslaris/core/repository/RefreshTokenRepository.java
+++ b/src/main/java/rs/teslaris/core/repository/RefreshTokenRepository.java
@@ -3,8 +3,10 @@ package rs.teslaris.core.repository;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 import rs.teslaris.core.model.RefreshToken;
 
+@Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Integer> {
 
     @Query("select t from RefreshToken t where t.refreshTokenValue = :refreshTokenValue")

--- a/src/main/java/rs/teslaris/core/service/UserService.java
+++ b/src/main/java/rs/teslaris/core/service/UserService.java
@@ -4,15 +4,20 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 import rs.teslaris.core.dto.AuthenticationRequestDTO;
+import rs.teslaris.core.dto.AuthenticationResponseDTO;
 import rs.teslaris.core.dto.TakeRoleOfUserRequestDTO;
 
 @Service
 public interface UserService extends UserDetailsService {
 
-    String authenticateUser(AuthenticationManager authernticationManager,
-                            AuthenticationRequestDTO authenticationRequest, String fingerprint);
+    AuthenticationResponseDTO authenticateUser(AuthenticationManager authernticationManager,
+                                               AuthenticationRequestDTO authenticationRequest,
+                                               String fingerprint);
 
-    String takeRoleOfUser(TakeRoleOfUserRequestDTO takeRoleOfUserRequest, String fingerprint);
+    AuthenticationResponseDTO refreshToken(String refreshTokenValue, String fingerprint);
+
+    AuthenticationResponseDTO takeRoleOfUser(TakeRoleOfUserRequestDTO takeRoleOfUserRequest,
+                                             String fingerprint);
 
     void allowTakingRoleOfAccount(String bearerToken);
 }

--- a/src/main/java/rs/teslaris/core/service/UserService.java
+++ b/src/main/java/rs/teslaris/core/service/UserService.java
@@ -1,8 +1,18 @@
 package rs.teslaris.core.service;
 
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
+import rs.teslaris.core.dto.AuthenticationRequestDTO;
+import rs.teslaris.core.dto.TakeRoleOfUserRequestDTO;
 
 @Service
 public interface UserService extends UserDetailsService {
+
+    String authenticateUser(AuthenticationManager authernticationManager,
+                            AuthenticationRequestDTO authenticationRequest, String fingerprint);
+
+    String takeRoleOfUser(TakeRoleOfUserRequestDTO takeRoleOfUserRequest, String fingerprint);
+
+    void allowTakingRoleOfAccount(String bearerToken);
 }

--- a/src/main/java/rs/teslaris/core/service/impl/UserServiceImpl.java
+++ b/src/main/java/rs/teslaris/core/service/impl/UserServiceImpl.java
@@ -1,5 +1,7 @@
 package rs.teslaris.core.service.impl;
 
+import com.google.common.hash.Hashing;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -58,8 +60,11 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public AuthenticationResponseDTO refreshToken(String refreshTokenValue, String fingerprint) {
+        var hashedRefreshToken = Hashing.sha256()
+            .hashString(refreshTokenValue, StandardCharsets.UTF_8)
+            .toString();
 
-        var refreshToken = refreshTokenRepository.getRefreshToken(refreshTokenValue).orElseThrow(
+        var refreshToken = refreshTokenRepository.getRefreshToken(hashedRefreshToken).orElseThrow(
             () -> new NonExistingRefreshTokenException("Non existing refresh token provided."));
 
         var newRefreshToken = createAndSaveRefreshTokenForUser(refreshToken.getUser());
@@ -101,7 +106,10 @@ public class UserServiceImpl implements UserService {
 
     private String createAndSaveRefreshTokenForUser(User user) {
         var refreshTokenValue = UUID.randomUUID().toString();
-        refreshTokenRepository.save(new RefreshToken(refreshTokenValue, user));
+        var hashedRefreshToken = Hashing.sha256()
+            .hashString(refreshTokenValue, StandardCharsets.UTF_8)
+            .toString();
+        refreshTokenRepository.save(new RefreshToken(hashedRefreshToken, user));
 
         return refreshTokenValue;
     }

--- a/src/main/java/rs/teslaris/core/service/impl/UserServiceImpl.java
+++ b/src/main/java/rs/teslaris/core/service/impl/UserServiceImpl.java
@@ -1,15 +1,25 @@
 package rs.teslaris.core.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import rs.teslaris.core.dto.AuthenticationRequestDTO;
+import rs.teslaris.core.dto.TakeRoleOfUserRequestDTO;
+import rs.teslaris.core.exception.TakeOfRoleNotPermittedException;
+import rs.teslaris.core.model.User;
 import rs.teslaris.core.repository.UserRepository;
 import rs.teslaris.core.service.UserService;
+import rs.teslaris.core.util.jwt.JwtUtil;
 
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
+
+    private final JwtUtil tokenUtil;
 
     private final UserRepository userRepository;
 
@@ -17,5 +27,44 @@ public class UserServiceImpl implements UserService {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         return userRepository.findByEmail(username).orElseThrow(
             () -> new UsernameNotFoundException("User with this email does not exist."));
+    }
+
+    @Override
+    public String authenticateUser(AuthenticationManager authenticationManager,
+                                   AuthenticationRequestDTO authenticationRequest,
+                                   String fingerprint) {
+        var authentication = authenticationManager.authenticate(
+            new UsernamePasswordAuthenticationToken(authenticationRequest.getEmail(),
+                authenticationRequest.getPassword())
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return tokenUtil.generateToken(authentication, fingerprint);
+    }
+
+    @Override
+    public String takeRoleOfUser(TakeRoleOfUserRequestDTO takeRoleOfUserRequest,
+                                 String fingerprint) {
+        var user = (User) loadUserByUsername(takeRoleOfUserRequest.getUserEmail());
+
+        if (!user.getCanTakeRole()) {
+            throw new TakeOfRoleNotPermittedException(
+                "User did not allow taking control of his account.");
+        }
+
+        user.setCanTakeRole(false);
+        userRepository.save(user);
+
+        return tokenUtil.generateToken(user, fingerprint);
+    }
+
+    @Override
+    public void allowTakingRoleOfAccount(String bearerToken) {
+        var email = tokenUtil.extractUsernameFromToken(bearerToken.split(" ")[1]);
+
+        var user = (User) loadUserByUsername(email);
+        user.setCanTakeRole(true);
+
+        userRepository.save(user);
     }
 }

--- a/src/main/java/rs/teslaris/core/util/jwt/JwtUtil.java
+++ b/src/main/java/rs/teslaris/core/util/jwt/JwtUtil.java
@@ -3,6 +3,13 @@ package rs.teslaris.core.util.jwt;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Date;
+import java.util.function.Function;
+import javax.xml.bind.DatatypeConverter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -10,31 +17,18 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import rs.teslaris.core.model.User;
 
-import javax.xml.bind.DatatypeConverter;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.util.Date;
-import java.util.function.Function;
-
 @Slf4j
 @Component
 public class JwtUtil {
 
+    public static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS512;
+    private final SecureRandom secureRandom = new SecureRandom();
     @Value("${jwt.token.validity}")
     public Long tokenValidity;
-
     @Value("${jwt.signing.key}")
     public String signingKey;
-
     @Value("${spring.application.name}")
     public String appName;
-
-
-    private final SecureRandom secureRandom = new SecureRandom();
-
-    public static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS512;
 
     public String extractUsernameFromToken(String token) {
         return extractClaim(token, Claims::getSubject);
@@ -56,9 +50,9 @@ public class JwtUtil {
 
     private Claims getAllClaimsFromToken(String token) {
         return Jwts.parser()
-                .setSigningKey(signingKey)
-                .parseClaimsJws(token)
-                .getBody();
+            .setSigningKey(signingKey)
+            .parseClaimsJws(token)
+            .getBody();
     }
 
     private Boolean isTokenExpired(String token) {
@@ -70,18 +64,34 @@ public class JwtUtil {
         String jwtSecurityHash = this.generateJWTSecurityFingerprintHash(fingerprint);
         var user = (User) authentication.getPrincipal();
 
+        return Jwts.builder()
+            .setHeaderParam("typ", "JWT")
+            .setIssuer(appName)
+            .setSubject(authentication.getName())
+            .claim("jwt-security-fingerprint", jwtSecurityHash)
+            .claim("role", user.getAuthority().getName())
+            .claim("userId", user.getId())
+            .setIssuedAt(new Date(System.currentTimeMillis()))
+            .setExpiration(new Date(System.currentTimeMillis() + tokenValidity))
+            .signWith(signatureAlgorithm, signingKey)
+            .compact();
+    }
+
+    public String generateToken(UserDetails userDetails, String fingerprint) {
+        String jwtSecurityHash = this.generateJWTSecurityFingerprintHash(fingerprint);
+        var user = (User) userDetails;
 
         return Jwts.builder()
-                .setHeaderParam("typ", "JWT")
-                .setIssuer(appName)
-                .setSubject(authentication.getName())
-                .claim("jwt-security-fingerprint", jwtSecurityHash)
-                .claim("role", user.getAuthority().getName())
-                .claim("userId", user.getId())
-                .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + tokenValidity))
-                .signWith(signatureAlgorithm, signingKey)
-                .compact();
+            .setHeaderParam("typ", "JWT")
+            .setIssuer(appName)
+            .setSubject(user.getEmail())
+            .claim("jwt-security-fingerprint", jwtSecurityHash)
+            .claim("role", user.getAuthority().getName())
+            .claim("userId", user.getId())
+            .setIssuedAt(new Date(System.currentTimeMillis()))
+            .setExpiration(new Date(System.currentTimeMillis() + tokenValidity))
+            .signWith(signatureAlgorithm, signingKey)
+            .compact();
     }
 
     public String generateJWTSecurityFingerprint() {
@@ -95,7 +105,8 @@ public class JwtUtil {
         // Generisanje hash-a za fingerprint koji stavljamo u token (sprecavamo XSS da procita fingerprint i sam postavi ocekivani cookie)
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] userFingerprintDigest = digest.digest(jwtSecurity.getBytes(StandardCharsets.UTF_8));
+            byte[] userFingerprintDigest =
+                digest.digest(jwtSecurity.getBytes(StandardCharsets.UTF_8));
             return DatatypeConverter.printHexBinary(userFingerprintDigest);
         } catch (NoSuchAlgorithmException e) {
             e.printStackTrace();
@@ -103,13 +114,12 @@ public class JwtUtil {
         }
     }
 
-
     public boolean checkAlgHeaderParam(String token) {
         var algorithm = Jwts.parser()
-                .setSigningKey(signingKey)
-                .parseClaimsJws(token)
-                .getHeader()
-                .getAlgorithm();
+            .setSigningKey(signingKey)
+            .parseClaimsJws(token)
+            .getHeader()
+            .getAlgorithm();
         return algorithm.equals(signatureAlgorithm.getValue());
     }
 
@@ -118,7 +128,8 @@ public class JwtUtil {
         String jwtSecurityHash = this.generateJWTSecurityFingerprintHash(cookieValue);
         String jwtSecurity = this.extractJWTSecurity(token);
 
-        return (username.equals(userDetails.getUsername()) && !isTokenExpired(token)) && jwtSecurity.equals(jwtSecurityHash);
+        return (username.equals(userDetails.getUsername()) && !isTokenExpired(token)) &&
+            jwtSecurity.equals(jwtSecurityHash);
     }
 
     public Boolean validateToken(String token, UserDetails userDetails) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,7 +16,7 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.open-in-view=false
 
 # JWT
-jwt.token.validity=90000000
+jwt.token.validity=900000
 jwt.signing.key=${JWT_SIGNING_KEY:signingkey}
 jwt.token.prefix=Bearer
 jwt.header.string=Authorization


### PR DESCRIPTION
Added possibility to [take user role](https://github.com/chenejac/TeslaRIS-backend/issues/13) in order to have their point of view when debugging problems.

For functionality to work, user must first allow admin to take control using ```api/user/allow-role-taking``` endpoint, after which, any admin can take control of the account simply by knowing user's email, but only for one login session (after which the access is revoked).

Admins have this functionality disabled by not having permission to allow role taking for their account.